### PR TITLE
ci: don't run tests for doc only changes

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -4,11 +4,15 @@ on:
   pull_request:
     branches:
       - '*'
+    paths-ignore:
+      - '**/**.md'
   push:
     branches:
       - 'main'
     tags:
       - '*'
+    paths-ignore:
+      - '**/**.md'
   workflow_dispatch: {}
 
 jobs:


### PR DESCRIPTION
**What this PR does / why we need it**: To prevent running tests for doc only changes

**Which issue this PR fixes**: #16 
