### PR TITLE
fix: Use namespace (as intended) instead of name when manipulating control plane in env setup

### DIFF
--- a/controllers/controlplane_controller.go
+++ b/controllers/controlplane_controller.go
@@ -56,7 +56,7 @@ func (r *ControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	debug(log, "validating ControlPlane configuration", controlplane)
 	if len(controlplane.Spec.Env) == 0 && len(controlplane.Spec.EnvFrom) == 0 {
 		debug(log, "no ENV config found for ControlPlane resource, setting defaults", controlplane)
-		setControlPlaneDefaults(&controlplane.Spec.ControlPlaneDeploymentOptions, controlplane.Name, nil)
+		setControlPlaneDefaults(&controlplane.Spec.ControlPlaneDeploymentOptions, controlplane.Namespace, nil)
 		if err := r.Client.Update(ctx, controlplane); err != nil {
 			if errors.IsConflict(err) {
 				debug(log, "conflict found when updating ControlPlane resource, retrying", controlplane)

--- a/test/integration/asserts_test.go
+++ b/test/integration/asserts_test.go
@@ -1,0 +1,61 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+
+	operatorv1alpha1 "github.com/kong/gateway-operator/api/v1alpha1"
+	"github.com/kong/gateway-operator/internal/consts"
+	k8sutils "github.com/kong/gateway-operator/internal/utils/kubernetes"
+)
+
+// mustListDataPlaneDeployments is a helper function for tests that
+// conveniently lists all deployments managed by a given dataplane.
+func mustListDataPlaneDeployments(t *testing.T, dataplane *operatorv1alpha1.DataPlane) []v1.Deployment {
+	deployments, err := k8sutils.ListDeploymentsForOwner(
+		ctx,
+		mgrClient,
+		consts.GatewayOperatorControlledLabel,
+		consts.DataPlaneManagedLabelValue,
+		dataplane.Namespace,
+		dataplane.UID,
+	)
+	require.NoError(t, err)
+	return deployments
+}
+
+// mustListControlPlaneDeployments is a helper function for tests that
+// conveniently lists all deployments managed by a given controlplane.
+func mustListControlPlaneDeployments(t *testing.T, controlplane *operatorv1alpha1.ControlPlane) []v1.Deployment {
+	deployments, err := k8sutils.ListDeploymentsForOwner(
+		ctx,
+		mgrClient,
+		consts.GatewayOperatorControlledLabel,
+		consts.ControlPlaneManagedLabelValue,
+		controlplane.Namespace,
+		controlplane.UID,
+	)
+	require.NoError(t, err)
+	return deployments
+}
+
+// mustListServices is a helper function for tests that
+// conveniently lists all services managed by a given dataplane.
+func mustListDataPlaneServices(t *testing.T, dataplane *operatorv1alpha1.DataPlane) []corev1.Service {
+	services, err := k8sutils.ListServicesForOwner(
+		ctx,
+		mgrClient,
+		consts.GatewayOperatorControlledLabel,
+		consts.DataPlaneManagedLabelValue,
+		dataplane.Namespace,
+		dataplane.UID,
+	)
+	require.NoError(t, err)
+	return services
+}

--- a/test/integration/controlplane_test.go
+++ b/test/integration/controlplane_test.go
@@ -1,0 +1,101 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/gateway-operator/api/v1alpha1"
+	operatorv1alpha1 "github.com/kong/gateway-operator/api/v1alpha1"
+	"github.com/kong/gateway-operator/controllers"
+)
+
+func TestControlPlaneEssentials(t *testing.T) {
+	namespace, cleaner := setup(t)
+	defer func() { assert.NoError(t, cleaner.Cleanup(ctx)) }()
+
+	dataplaneClient := operatorClient.V1alpha1().DataPlanes(namespace.Name)
+	controlplaneClient := operatorClient.V1alpha1().ControlPlanes(namespace.Name)
+
+	// Control plane needs a dataplane to exist to properly function.
+	dataplane := &v1alpha1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace.Name,
+			Name:      uuid.NewString(),
+		},
+	}
+
+	controlplane := &operatorv1alpha1.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace.Name,
+			Name:      uuid.NewString(),
+		},
+		Spec: operatorv1alpha1.ControlPlaneSpec{
+			ControlPlaneDeploymentOptions: operatorv1alpha1.ControlPlaneDeploymentOptions{
+				DataPlane: &dataplane.Name,
+			},
+		},
+	}
+
+	t.Log("deploying dataplane resource")
+	dataplane, err := dataplaneClient.Create(ctx, dataplane, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(dataplane)
+
+	t.Log("verifying deployments managed by the dataplane are ready")
+	require.Eventually(t, func() bool {
+		deployments := mustListDataPlaneDeployments(t, dataplane)
+		return len(deployments) == 1 &&
+			deployments[0].Status.AvailableReplicas >= deployments[0].Status.ReadyReplicas
+	}, time.Minute, time.Second)
+
+	t.Log("verifying services managed by the dataplane")
+	require.Eventually(t, func() bool {
+		services := mustListDataPlaneServices(t, dataplane)
+		if len(services) == 1 {
+			return true
+		}
+		return false
+	}, time.Minute, time.Second)
+
+	t.Log("deploying controlplane resource")
+	controlplane, err = controlplaneClient.Create(ctx, controlplane, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(controlplane)
+
+	t.Log("verifying controlplane gets marked scheduled")
+	require.Eventually(t, controlPlanePredicate(t, controlplane, func(controlplane *operatorv1alpha1.ControlPlane) bool {
+		for _, condition := range controlplane.Status.Conditions {
+			if condition.Type == string(controllers.ControlPlaneConditionTypeProvisioned) {
+				return true
+			}
+		}
+		return false
+	}), time.Minute, time.Second)
+
+	t.Log("verifying that the controlplane gets marked as provisioned")
+	require.Eventually(t, controlPlanePredicate(t, controlplane, func(controlplane *operatorv1alpha1.ControlPlane) bool {
+		for _, condition := range controlplane.Status.Conditions {
+			if condition.Type == string(controllers.ControlPlaneConditionTypeProvisioned) &&
+				condition.Status == metav1.ConditionTrue {
+				return true
+			}
+		}
+		return false
+	}), 2*time.Minute, time.Second)
+
+	t.Log("verifying controlplane deployment has active replicas")
+	require.Eventually(t, func() bool {
+		deployments := mustListControlPlaneDeployments(t, controlplane)
+		return len(deployments) == 1 &&
+			*deployments[0].Spec.Replicas > 0 &&
+			deployments[0].Status.AvailableReplicas >= deployments[0].Status.ReadyReplicas
+	}, time.Minute, time.Second)
+}

--- a/test/integration/controlplane_test.go
+++ b/test/integration/controlplane_test.go
@@ -71,25 +71,27 @@ func TestControlPlaneEssentials(t *testing.T) {
 	cleaner.Add(controlplane)
 
 	t.Log("verifying controlplane gets marked scheduled")
-	require.Eventually(t, controlPlanePredicate(t, controlplane, func(controlplane *operatorv1alpha1.ControlPlane) bool {
-		for _, condition := range controlplane.Status.Conditions {
+	isScheduled := func(c *operatorv1alpha1.ControlPlane) bool {
+		for _, condition := range c.Status.Conditions {
 			if condition.Type == string(controllers.ControlPlaneConditionTypeProvisioned) {
 				return true
 			}
 		}
 		return false
-	}), time.Minute, time.Second)
+	}
+	require.Eventually(t, controlPlanePredicate(t, controlplane.Namespace, controlplane.Name, isScheduled), time.Minute, time.Second)
 
 	t.Log("verifying that the controlplane gets marked as provisioned")
-	require.Eventually(t, controlPlanePredicate(t, controlplane, func(controlplane *operatorv1alpha1.ControlPlane) bool {
-		for _, condition := range controlplane.Status.Conditions {
+	isProvisioned := func(c *operatorv1alpha1.ControlPlane) bool {
+		for _, condition := range c.Status.Conditions {
 			if condition.Type == string(controllers.ControlPlaneConditionTypeProvisioned) &&
 				condition.Status == metav1.ConditionTrue {
 				return true
 			}
 		}
 		return false
-	}), 2*time.Minute, time.Second)
+	}
+	require.Eventually(t, controlPlanePredicate(t, controlplane.Namespace, controlplane.Name, isProvisioned), 2*time.Minute, time.Second)
 
 	t.Log("verifying controlplane deployment has active replicas")
 	require.Eventually(t, func() bool {

--- a/test/integration/dataplane_test.go
+++ b/test/integration/dataplane_test.go
@@ -35,24 +35,26 @@ func TestDataplaneEssentials(t *testing.T) {
 	cleaner.Add(dataplane)
 
 	t.Log("verifying dataplane gets marked scheduled")
-	require.Eventually(t, dataPlanePredicate(t, dataplane, func(dataplane *v1alpha1.DataPlane) bool {
+	isScheduled := func(dataplane *v1alpha1.DataPlane) bool {
 		for _, condition := range dataplane.Status.Conditions {
 			if condition.Type == string(controllers.DataPlaneConditionTypeProvisioned) {
 				return true
 			}
 		}
 		return false
-	}), time.Minute, time.Second)
+	}
+	require.Eventually(t, dataPlanePredicate(t, dataplane.Namespace, dataplane.Name, isScheduled), time.Minute, time.Second)
 
 	t.Log("verifying that the dataplane gets marked as provisioned")
-	require.Eventually(t, dataPlanePredicate(t, dataplane, func(dataplane *v1alpha1.DataPlane) bool {
+	isProvisioned := func(dataplane *v1alpha1.DataPlane) bool {
 		for _, condition := range dataplane.Status.Conditions {
 			if condition.Type == string(controllers.DataPlaneConditionTypeProvisioned) && condition.Status == metav1.ConditionTrue {
 				return true
 			}
 		}
 		return false
-	}), time.Minute, time.Second)
+	}
+	require.Eventually(t, dataPlanePredicate(t, dataplane.Namespace, dataplane.Name, isProvisioned), time.Minute, time.Second)
 
 	t.Log("verifying deployments managed by the dataplane")
 	require.Eventually(t, func() bool {

--- a/test/integration/dataplane_test.go
+++ b/test/integration/dataplane_test.go
@@ -17,8 +17,6 @@ import (
 
 	"github.com/kong/gateway-operator/api/v1alpha1"
 	"github.com/kong/gateway-operator/controllers"
-	"github.com/kong/gateway-operator/internal/consts"
-	k8sutils "github.com/kong/gateway-operator/internal/utils/kubernetes"
 )
 
 func TestDataplaneEssentials(t *testing.T) {
@@ -37,59 +35,35 @@ func TestDataplaneEssentials(t *testing.T) {
 	cleaner.Add(dataplane)
 
 	t.Log("verifying dataplane gets marked scheduled")
-	require.Eventually(t, func() bool {
-		dataplane, err = operatorClient.V1alpha1().DataPlanes(namespace.Name).Get(ctx, dataplane.Name, metav1.GetOptions{})
-		require.NoError(t, err)
-		isScheduled := false
+	require.Eventually(t, dataPlanePredicate(t, dataplane, func(dataplane *v1alpha1.DataPlane) bool {
 		for _, condition := range dataplane.Status.Conditions {
 			if condition.Type == string(controllers.DataPlaneConditionTypeProvisioned) {
-				isScheduled = true
+				return true
 			}
 		}
-		return isScheduled
-	}, time.Minute, time.Second)
+		return false
+	}), time.Minute, time.Second)
 
 	t.Log("verifying that the dataplane gets marked as provisioned")
-	require.Eventually(t, func() bool {
-		dataplane, err = operatorClient.V1alpha1().DataPlanes(namespace.Name).Get(ctx, dataplane.Name, metav1.GetOptions{})
-		if err != nil {
-			return false
-		}
-		isProvisioned := false
+	require.Eventually(t, dataPlanePredicate(t, dataplane, func(dataplane *v1alpha1.DataPlane) bool {
 		for _, condition := range dataplane.Status.Conditions {
 			if condition.Type == string(controllers.DataPlaneConditionTypeProvisioned) && condition.Status == metav1.ConditionTrue {
-				isProvisioned = true
+				return true
 			}
 		}
-		return isProvisioned
-	}, time.Minute*2, time.Second)
+		return false
+	}), time.Minute, time.Second)
 
 	t.Log("verifying deployments managed by the dataplane")
 	require.Eventually(t, func() bool {
-		deployments, err := k8sutils.ListDeploymentsForOwner(
-			ctx,
-			mgrClient,
-			consts.GatewayOperatorControlledLabel,
-			consts.DataPlaneManagedLabelValue,
-			dataplane.Namespace,
-			dataplane.UID,
-		)
-		require.NoError(t, err)
+		deployments := mustListDataPlaneDeployments(t, dataplane)
 		return len(deployments) == 1 && deployments[0].Status.AvailableReplicas >= deployments[0].Status.ReadyReplicas
 	}, time.Minute, time.Second)
 
 	t.Log("verifying services managed by the dataplane")
 	var dataplaneService *corev1.Service
 	require.Eventually(t, func() bool {
-		services, err := k8sutils.ListServicesForOwner(
-			ctx,
-			mgrClient,
-			consts.GatewayOperatorControlledLabel,
-			consts.DataPlaneManagedLabelValue,
-			dataplane.Namespace,
-			dataplane.UID,
-		)
-		require.NoError(t, err)
+		services := mustListDataPlaneServices(t, dataplane)
 		if len(services) == 1 {
 			dataplaneService = &services[0]
 			return true

--- a/test/integration/predicates_test.go
+++ b/test/integration/predicates_test.go
@@ -1,0 +1,43 @@
+//go:build integration_tests
+// +build integration_tests
+
+package integration
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/kong/gateway-operator/api/v1alpha1"
+)
+
+// controlPlanePredicate is a helper function for tests that returns a function
+// that can be used to check if a ControlPlane has a certain state.
+func controlPlanePredicate(
+	t *testing.T,
+	controlplane *operatorv1alpha1.ControlPlane,
+	predicate func(controlplane *operatorv1alpha1.ControlPlane) bool,
+) func() bool {
+	controlplaneClient := operatorClient.V1alpha1().ControlPlanes(controlplane.Namespace)
+	return func() bool {
+		controlplane, err := controlplaneClient.Get(ctx, controlplane.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return predicate(controlplane)
+	}
+}
+
+// dataPlanePredicate is a helper function for tests that returns a function
+// that can be used to check if a DataPlane has a certain state.
+func dataPlanePredicate(
+	t *testing.T,
+	dataplane *operatorv1alpha1.DataPlane,
+	predicate func(dataplane *operatorv1alpha1.DataPlane) bool,
+) func() bool {
+	dataPlaneClient := operatorClient.V1alpha1().DataPlanes(dataplane.Namespace)
+	return func() bool {
+		dataplane, err := dataPlaneClient.Get(ctx, dataplane.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return predicate(dataplane)
+	}
+}

--- a/test/integration/predicates_test.go
+++ b/test/integration/predicates_test.go
@@ -16,12 +16,12 @@ import (
 // that can be used to check if a ControlPlane has a certain state.
 func controlPlanePredicate(
 	t *testing.T,
-	controlplane *operatorv1alpha1.ControlPlane,
+	controlPlaneNamespace, controlPlaneName string,
 	predicate func(controlplane *operatorv1alpha1.ControlPlane) bool,
 ) func() bool {
-	controlplaneClient := operatorClient.V1alpha1().ControlPlanes(controlplane.Namespace)
+	controlplaneClient := operatorClient.V1alpha1().ControlPlanes(controlPlaneNamespace)
 	return func() bool {
-		controlplane, err := controlplaneClient.Get(ctx, controlplane.Name, metav1.GetOptions{})
+		controlplane, err := controlplaneClient.Get(ctx, controlPlaneName, metav1.GetOptions{})
 		require.NoError(t, err)
 		return predicate(controlplane)
 	}
@@ -31,12 +31,12 @@ func controlPlanePredicate(
 // that can be used to check if a DataPlane has a certain state.
 func dataPlanePredicate(
 	t *testing.T,
-	dataplane *operatorv1alpha1.DataPlane,
+	dataplaneNamespace, dataplaneName string,
 	predicate func(dataplane *operatorv1alpha1.DataPlane) bool,
 ) func() bool {
-	dataPlaneClient := operatorClient.V1alpha1().DataPlanes(dataplane.Namespace)
+	dataPlaneClient := operatorClient.V1alpha1().DataPlanes(dataplaneNamespace)
 	return func() bool {
-		dataplane, err := dataPlaneClient.Get(ctx, dataplane.Name, metav1.GetOptions{})
+		dataplane, err := dataPlaneClient.Get(ctx, dataplaneName, metav1.GetOptions{})
 		require.NoError(t, err)
 		return predicate(dataplane)
 	}

--- a/test/integration/util_test.go
+++ b/test/integration/util_test.go
@@ -9,13 +9,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	operatorv1alpha1 "github.com/kong/gateway-operator/api/v1alpha1"
-	"github.com/kong/gateway-operator/internal/consts"
-	k8sutils "github.com/kong/gateway-operator/internal/utils/kubernetes"
 )
 
 // setup is a helper function for tests which conveniently creates a cluster
@@ -37,79 +32,4 @@ func setup(t *testing.T) (*corev1.Namespace, *clusters.Cleaner) {
 	cleaner.AddNamespace(namespace)
 
 	return namespace, cleaner
-}
-
-// mustListDataPlaneDeployments is a helper function for tests that
-// conveniently lists all deployments managed by a given dataplane.
-func mustListDataPlaneDeployments(t *testing.T, dataplane *operatorv1alpha1.DataPlane) []v1.Deployment {
-	deployments, err := k8sutils.ListDeploymentsForOwner(
-		ctx,
-		mgrClient,
-		consts.GatewayOperatorControlledLabel,
-		consts.DataPlaneManagedLabelValue,
-		dataplane.Namespace,
-		dataplane.UID,
-	)
-	require.NoError(t, err)
-	return deployments
-}
-
-// mustListControlPlaneDeployments is a helper function for tests that
-// conveniently lists all deployments managed by a given controlplane.
-func mustListControlPlaneDeployments(t *testing.T, controlplane *operatorv1alpha1.ControlPlane) []v1.Deployment {
-	deployments, err := k8sutils.ListDeploymentsForOwner(
-		ctx,
-		mgrClient,
-		consts.GatewayOperatorControlledLabel,
-		consts.ControlPlaneManagedLabelValue,
-		controlplane.Namespace,
-		controlplane.UID,
-	)
-	require.NoError(t, err)
-	return deployments
-}
-
-// mustListServices is a helper function for tests that
-// conveniently lists all services managed by a given dataplane.
-func mustListDataPlaneServices(t *testing.T, dataplane *operatorv1alpha1.DataPlane) []corev1.Service {
-	services, err := k8sutils.ListServicesForOwner(
-		ctx,
-		mgrClient,
-		consts.GatewayOperatorControlledLabel,
-		consts.DataPlaneManagedLabelValue,
-		dataplane.Namespace,
-		dataplane.UID,
-	)
-	require.NoError(t, err)
-	return services
-}
-
-// controlPlanePredicate is a helper function for tests that returns a function
-// that can be used to check if a ControlPlane has a certain state.
-func controlPlanePredicate(
-	t *testing.T,
-	controlplane *operatorv1alpha1.ControlPlane,
-	predicate func(controlplane *operatorv1alpha1.ControlPlane) bool,
-) func() bool {
-	controlplaneClient := operatorClient.V1alpha1().ControlPlanes(controlplane.Namespace)
-	return func() bool {
-		controlplane, err := controlplaneClient.Get(ctx, controlplane.Name, metav1.GetOptions{})
-		require.NoError(t, err)
-		return predicate(controlplane)
-	}
-}
-
-// dataPlanePredicate is a helper function for tests that returns a function
-// that can be used to check if a DataPlane has a certain state.
-func dataPlanePredicate(
-	t *testing.T,
-	dataplane *operatorv1alpha1.DataPlane,
-	predicate func(dataplane *operatorv1alpha1.DataPlane) bool,
-) func() bool {
-	dataPlaneClient := operatorClient.V1alpha1().DataPlanes(dataplane.Namespace)
-	return func() bool {
-		dataplane, err := dataPlaneClient.Get(ctx, dataplane.Name, metav1.GetOptions{})
-		require.NoError(t, err)
-		return predicate(dataplane)
-	}
 }

--- a/test/integration/util_test.go
+++ b/test/integration/util_test.go
@@ -9,8 +9,13 @@ import (
 	"github.com/google/uuid"
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
 	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	operatorv1alpha1 "github.com/kong/gateway-operator/api/v1alpha1"
+	"github.com/kong/gateway-operator/internal/consts"
+	k8sutils "github.com/kong/gateway-operator/internal/utils/kubernetes"
 )
 
 // setup is a helper function for tests which conveniently creates a cluster
@@ -32,4 +37,79 @@ func setup(t *testing.T) (*corev1.Namespace, *clusters.Cleaner) {
 	cleaner.AddNamespace(namespace)
 
 	return namespace, cleaner
+}
+
+// mustListDataPlaneDeployments is a helper function for tests that
+// conveniently lists all deployments managed by a given dataplane.
+func mustListDataPlaneDeployments(t *testing.T, dataplane *operatorv1alpha1.DataPlane) []v1.Deployment {
+	deployments, err := k8sutils.ListDeploymentsForOwner(
+		ctx,
+		mgrClient,
+		consts.GatewayOperatorControlledLabel,
+		consts.DataPlaneManagedLabelValue,
+		dataplane.Namespace,
+		dataplane.UID,
+	)
+	require.NoError(t, err)
+	return deployments
+}
+
+// mustListControlPlaneDeployments is a helper function for tests that
+// conveniently lists all deployments managed by a given controlplane.
+func mustListControlPlaneDeployments(t *testing.T, controlplane *operatorv1alpha1.ControlPlane) []v1.Deployment {
+	deployments, err := k8sutils.ListDeploymentsForOwner(
+		ctx,
+		mgrClient,
+		consts.GatewayOperatorControlledLabel,
+		consts.ControlPlaneManagedLabelValue,
+		controlplane.Namespace,
+		controlplane.UID,
+	)
+	require.NoError(t, err)
+	return deployments
+}
+
+// mustListServices is a helper function for tests that
+// conveniently lists all services managed by a given dataplane.
+func mustListDataPlaneServices(t *testing.T, dataplane *operatorv1alpha1.DataPlane) []corev1.Service {
+	services, err := k8sutils.ListServicesForOwner(
+		ctx,
+		mgrClient,
+		consts.GatewayOperatorControlledLabel,
+		consts.DataPlaneManagedLabelValue,
+		dataplane.Namespace,
+		dataplane.UID,
+	)
+	require.NoError(t, err)
+	return services
+}
+
+// controlPlanePredicate is a helper function for tests that returns a function
+// that can be used to check if a ControlPlane has a certain state.
+func controlPlanePredicate(
+	t *testing.T,
+	controlplane *operatorv1alpha1.ControlPlane,
+	predicate func(controlplane *operatorv1alpha1.ControlPlane) bool,
+) func() bool {
+	controlplaneClient := operatorClient.V1alpha1().ControlPlanes(controlplane.Namespace)
+	return func() bool {
+		controlplane, err := controlplaneClient.Get(ctx, controlplane.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return predicate(controlplane)
+	}
+}
+
+// dataPlanePredicate is a helper function for tests that returns a function
+// that can be used to check if a DataPlane has a certain state.
+func dataPlanePredicate(
+	t *testing.T,
+	dataplane *operatorv1alpha1.DataPlane,
+	predicate func(dataplane *operatorv1alpha1.DataPlane) bool,
+) func() bool {
+	dataPlaneClient := operatorClient.V1alpha1().DataPlanes(dataplane.Namespace)
+	return func() bool {
+		dataplane, err := dataPlaneClient.Get(ctx, dataplane.Name, metav1.GetOptions{})
+		require.NoError(t, err)
+		return predicate(dataplane)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

- Fixes problem introduced in https://github.com/Kong/gateway-operator/commit/e7ec615494f5b7412e327b3db9f700d35e4200f2#diff-c38af0b84f605ebcf275bd2a3c3ec10b957c3611e9e471660fdc8586008c7276R76
- Use namespace (as intended) instead of name when manipulating control plane in env setup 
- Add tests for control plane essentials
- Add utility tests functions for common checks

**Which issue this PR fixes**

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
