### PR TITLE
Possibility to disable the leader election

### DIFF
--- a/internal/manager/run.go
+++ b/internal/manager/run.go
@@ -60,9 +60,9 @@ type Config struct {
 var DefaultConfig = Config{
 	MetricsAddr:     ":8080",
 	ProbeAddr:       ":8081",
-	LeaderElection:  true,
 	WebhookPort:     9443,
 	DevelopmentMode: false,
+	LeaderElection:  true,
 }
 
 func Run(cfg Config) error {

--- a/main.go
+++ b/main.go
@@ -30,18 +30,25 @@ import (
 func main() {
 	var metricsAddr string
 	var probeAddr string
-	var enableLeaderElection bool
+	var disableLeaderElection bool
 	var controllerName string
+
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.BoolVar(&enableLeaderElection, "leader-elect", manager.DefaultConfig.LeaderElection,
-		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
+	flag.BoolVar(&disableLeaderElection, "no-leader-election", false,
+		"Disable leader election for controller manager. Disabling this will not ensure there is only one active controller manager.")
 	flag.StringVar(&controllerName, "controller-name", "", "a controller name to use if other than the default, only needed for multi-tenancy")
 
 	developmentModeEnabled := manager.DefaultConfig.DevelopmentMode
 	if v := os.Getenv("CONTROLLER_DEVELOPMENT_MODE"); v == "true" { // TODO: clean env handling https://github.com/Kong/gateway-operator/issues/19
 		fmt.Println("INFO: development mode has been enabled")
 		developmentModeEnabled = true
+	}
+
+	leaderElection := manager.DefaultConfig.LeaderElection
+	if disableLeaderElection {
+		fmt.Println("INFO: leader election has been disabled")
+		leaderElection = false
 	}
 
 	opts := zap.Options{
@@ -56,7 +63,7 @@ func main() {
 	cfg := manager.Config{
 		MetricsAddr:    metricsAddr,
 		ProbeAddr:      probeAddr,
-		LeaderElection: enableLeaderElection,
+		LeaderElection: leaderElection,
 		ControllerName: controllerName,
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:
The `--leader-elect` flag is replaced by `--no-leader-election`. The leader election is enabled by default and can be disabled by using such a flag.

**Which issue this PR fixes**
Fixes #55 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
