### PR TITLE
fix: remove remaining --leader-elect flag usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,11 +246,11 @@ endif
 .PHONY: run
 run: manifests generate fmt vet install ## Run a controller from your host.
 	kubectl kustomize https://github.com/kubernetes-sigs/gateway-api.git/config/crd?ref=master | kubectl apply -f -
-	CONTROLLER_DEVELOPMENT_MODE=true go run ./main.go --leader-elect=false
+	CONTROLLER_DEVELOPMENT_MODE=true go run ./main.go --no-leader-election
 
 .PHONY: debug
 debug: manifests generate fmt vet install
-	CONTROLLER_DEVELOPMENT_MODE=true dlv debug ./main.go -- --leader-elect=false
+	CONTROLLER_DEVELOPMENT_MODE=true dlv debug ./main.go -- --no-leader-election
 
 .PHONY: install
 install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.

--- a/bundle/manifests/operator.clusterserviceversion.yaml
+++ b/bundle/manifests/operator.clusterserviceversion.yaml
@@ -237,7 +237,6 @@ spec:
               - args:
                 - --health-probe-bind-address=:8081
                 - --metrics-bind-address=127.0.0.1:8080
-                - --leader-elect
                 command:
                 - /manager
                 image: ghcr.io/kong/gateway-operator:main

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -29,4 +29,3 @@ spec:
         args:
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=127.0.0.1:8080"
-        - "--leader-elect"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -29,8 +29,6 @@ spec:
       containers:
       - command:
         - /manager
-        args:
-        - --leader-elect
         image: ghcr.io/kong/gateway-operator:main
         name: manager
         securityContext:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

PR https://github.com/Kong/gateway-operator/pull/68 removed `--leader-elect` flag. Some useses were left behind and for some reason e2t tests failed to catch that when run against previous PR, but detected missing flag and failed when run against the main branch.


**Which issue this PR fixes**

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
