### PR TITLE
tests: set up controller logger in integration tests before 30s deadline

### DIFF
--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -164,7 +164,7 @@ func setupControllerLogger() (closeLogFile func() error) {
 	var destWriter io.Writer = os.Stdout
 
 	if controllerManagerOut != "stdout" {
-		out, err := os.CreateTemp(os.TempDir(), "gateway-operator-controller-logs")
+		out, err := os.CreateTemp("", "gateway-operator-controller-logs")
 		exitOnErr(err)
 		fmt.Printf("INFO: controller output is being logged to %s\n", out.Name())
 		destWriter = out

--- a/test/integration/suite_test.go
+++ b/test/integration/suite_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -20,8 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
@@ -75,6 +78,9 @@ var (
 func TestMain(m *testing.M) {
 	ctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
+
+	closeControllerLogFile := setupControllerLogger()
+	defer closeControllerLogFile()
 
 	var skipClusterCleanup bool
 	var existingCluster clusters.Cluster
@@ -149,6 +155,39 @@ func exitOnErr(err error) {
 	}
 }
 
+// setupControllerLogger sets up the controller logger.
+// This functions needs to be called before 30sec after the controller packages
+// is loaded, otherwise the logger will not be initialized.
+// Returns the close function, that will close the log file if one was created.
+func setupControllerLogger() (closeLogFile func() error) {
+	var destFile *os.File
+	var destWriter io.Writer = os.Stdout
+
+	if controllerManagerOut != "stdout" {
+		out, err := os.CreateTemp(os.TempDir(), "gateway-operator-controller-logs")
+		exitOnErr(err)
+		fmt.Printf("INFO: controller output is being logged to %s\n", out.Name())
+		destWriter = out
+		destFile = out
+	}
+
+	opts := zap.Options{
+		Development: true,
+		DestWriter:  destWriter,
+	}
+
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	closeLogFile = func() error {
+		if destFile != nil {
+			return destFile.Close()
+		}
+		return nil
+	}
+
+	return closeLogFile
+}
+
 func startControllerManager() {
 	cfg := manager.DefaultConfig
 	cfg.LeaderElection = false
@@ -171,14 +210,6 @@ func startControllerManager() {
 			Client:          c,
 			UncachedObjects: uncachedObjects,
 		})
-	}
-
-	if controllerManagerOut != "stdout" {
-		out, err := os.CreateTemp(os.TempDir(), "gateway-operator-controller-logs")
-		exitOnErr(err)
-		cfg.Out = out
-		fmt.Printf("INFO: controller output is being logged to %s\n", out.Name())
-		defer out.Close()
 	}
 
 	exitOnErr(manager.Run(cfg))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

`sigs.k8s.io/controller-runtime` package has a deadline od `30s`, to set up a logger. After the time passes, the logger is set to nil logger and cannot be changed. 

This PR changes the integration tests setup order, so the controller logger is setup before setup of kind cluster begins. Kind cluster setup can take way more than `30s`, thus the logger needs to be in place before the kind cluster is created.

**Which issue this PR fixes**

Fixes #74


**Special notes for your reviewer**:

Tested manually by running integration tests

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
