### PR TITLE
feat(ci): enable auto-merge for dependabot

### DIFF
--- a/.github/workflows/automerge-dependabot.yaml
+++ b/.github/workflows/automerge-dependabot.yaml
@@ -1,0 +1,28 @@
+name: Enable auto-merge for dependabot
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot-automerge:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+    - name: Gather Dependabot metadata
+      id: metadata
+      uses: dependabot/fetch-metadata@v1.3.2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Approve PR
+      run: gh pr review --approve "$PR_URL"
+      env:
+        PR_URL: ${{github.event.pull_request.html_url}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Enable auto-merge
+      run: gh pr merge --auto --squash "$PR_URL"
+      env:
+        PR_URL: ${{github.event.pull_request.html_url}}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
**What this PR does / why we need it**:

In order to enable auto merge for dependabot's PRs.
