### PR TITLE
ci(Dockerfile): add Red Hat UBI docker build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,3 +42,4 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          target: distroless

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,63 @@ COPY internal/ internal/
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager main.go
 
-FROM gcr.io/distroless/static:nonroot
+### Distroless/default
+# Use distroless as minimal base image to package the operator binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot as distroless
+
+ARG TAG
+
+LABEL name="Kong Ingress Controller" \
+      vendor="Kong" \
+      version="$TAG" \
+      release="1" \
+      url="https://github.com/Kong/gateway-operator" \
+      summary="A Kubernetes Operator for the Kong Gateway." \
+      description="Kong Gateway Operator drives deployment via the Gateway resource. You can deploy a Gateway resource to the cluster which will result in the underlying control-plane (the Kong Kubernetes Ingress Controller) and the data-plane (the Kong Gateway)."
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532
 
+WORKDIR /
+COPY --from=builder /workspace/manager .
+USER 65532:65532
+
+
+
+ENTRYPOINT ["/manager"]
+
+### RHEL
+# Build UBI image
+FROM registry.access.redhat.com/ubi8/ubi AS redhat
+
+ARG TAG
+ARG NAME="Kong Gateway Operator"
+ARG DESCRIPTION="Kong Gateway Operator drives deployment via the Gateway resource. You can deploy a Gateway resource to the cluster which will result in the underlying control-plane (the Kong Kubernetes Ingress Controller) and the data-plane (the Kong Gateway)."
+
+
+LABEL name="$NAME" \
+      io.k8s.display-name="$NAME" \ 
+      vendor="Kong" \
+      version="$TAG" \
+      release="1" \
+      url="https://github.com/Kong/gateway-operator" \
+      summary="A Kubernetes Operator for the Kong Gateway." \
+      description="$DESCRIPTION" \
+      io.k8s.description="$DESCRIPTION"
+
+
+# Create the user (ID 1000) and group that will be used in the
+# running container to run the process as an unprivileged user.
+RUN groupadd --system gateway-operator && \
+    adduser --system gateway-operator -g gateway-operator -u 1000
+
+COPY --from=builder /workspace/manager .
+COPY LICENSE /licenses/
+
+# Perform any further action as an unprivileged user.
+USER 1000
+
+# Run the compiled binary.
 ENTRYPOINT ["/manager"]

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ SHELL = /usr/bin/env bash -o pipefail
 
 IMG ?= ghcr.io/kong/gateway-operator
 TAG ?= latest
+RHTAG ?= latest-redhat
 
 # ------------------------------------------------------------------------------
 # Configuration - OperatorHub
@@ -163,11 +164,15 @@ manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and Cust
 
 .PHONY: docker.build
 docker.build:
-	docker build -t ${IMG}:${TAG} .
+	docker build -t ${IMG}:${TAG} --target distroless --build-arg TAG=${TAG} . 
 
 .PHONY: docker.push
 docker.push:
 	docker push ${IMG}:${TAG}
+
+.PHONY: docker.build.redhat
+docker.build.redhat:
+	docker build -t ${IMG}:${RHTAG} --target redhat --build-arg TAG=${RHTAG} . 
 
 # ------------------------------------------------------------------------------
 # Build - OperatorHub Bundles


### PR DESCRIPTION


**What this PR does / why we need it**:

This PR modifies Dockerfile, adding an RedHat UBI build required for Redhat certification. Also adds makefiles targets for local testing.

**Which issue this PR fixes**

Fixes #59 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
