### PR TITLE
Add status and shotnames to CRDs

### DIFF
--- a/config/crd/bases/gateway-operator.konghq.com_controlplanes.yaml
+++ b/config/crd/bases/gateway-operator.konghq.com_controlplanes.yaml
@@ -13,6 +13,11 @@ spec:
     listKind: ControlPlaneList
     plural: controlplanes
     singular: controlplane
+    shortNames:
+      - kcp
+    categories:
+      - kong
+      - all
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -297,6 +302,15 @@ spec:
     storage: true
     subresources:
       status: {}
+    additionalPrinterColumns:
+      - name: Ready
+        type: string
+        description: The Resource is ready
+        jsonPath: .status.conditions[?(@.type=='Ready')].status
+      - name: Provisioned
+        type: string
+        description: The Resource is provisioned
+        jsonPath: .status.conditions[?(@.type=='Provisioned')].status
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/gateway-operator.konghq.com_dataplanes.yaml
+++ b/config/crd/bases/gateway-operator.konghq.com_dataplanes.yaml
@@ -13,6 +13,11 @@ spec:
     listKind: DataPlaneList
     plural: dataplanes
     singular: dataplane
+    shortNames:
+      - kdp
+    categories:
+      - kong
+      - all
   scope: Namespaced
   versions:
   - name: v1alpha1
@@ -270,6 +275,15 @@ spec:
     storage: true
     subresources:
       status: {}
+    additionalPrinterColumns:
+      - name: Ready
+        type: string
+        description: The Resource is ready
+        jsonPath: .status.conditions[?(@.type=='Ready')].status
+      - name: Provisioned
+        type: string
+        description: The Resource is provisioned
+        jsonPath: .status.conditions[?(@.type=='Provisioned')].status
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/gateway-operator.konghq.com_gatewayconfigurations.yaml
+++ b/config/crd/bases/gateway-operator.konghq.com_gatewayconfigurations.yaml
@@ -13,6 +13,11 @@ spec:
     listKind: GatewayConfigurationList
     plural: gatewayconfigurations
     singular: gatewayconfiguration
+    shortNames:
+      - kgc
+    categories:
+      - kong
+      - all
   scope: Namespaced
   versions:
   - name: v1alpha1


### PR DESCRIPTION
Signed-off-by: ruromero <rromerom@redhat.com>

It adds a bit of simplicity to the use of the Kong Gateway resources by adding short names, groups and additional columns.

* Groups
  * `kubectl get kong` we will get all the dataplane, controlplane and gatewayconfig resources in the namespace
  * `kubectl get all` it will retrieve not only pods, services, configmaps, etc. but also the Kong resources
* Short names
  * `kubectl get kcp` retrieves the Kong ControlPlanes
  * `kubectl get kdp` same for the DataPlanes
  * `kubectl get kgc` retrieves the Kong Gateway Configurations
* Additional Columns: Added the `Ready` and `Provisioned` printer columns for visibility.
