### PR TITLE
fix: always set controlplane default envs

### DIFF
--- a/controllers/controlplane_controller.go
+++ b/controllers/controlplane_controller.go
@@ -72,9 +72,12 @@ func (r *ControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	debug(log, "validating ControlPlane configuration", controlplane)
-	if len(controlplane.Spec.Env) == 0 && len(controlplane.Spec.EnvFrom) == 0 {
-		debug(log, "no ENV config found for ControlPlane resource, setting defaults", controlplane)
-		setControlPlaneDefaults(&controlplane.Spec.ControlPlaneDeploymentOptions, controlplane.Namespace, dataplaneServiceName, nil)
+	// TODO: add validating here
+
+	debug(log, "setting defaults for ControlPlane resource", controlplane)
+	changed := setControlPlaneDefaults(&controlplane.Spec.ControlPlaneDeploymentOptions, controlplane.Namespace, dataplaneServiceName, nil)
+	if changed {
+		debug(log, "updating ControlPlane resource after defaults are set since resource has changed", controlplane)
 		err := r.Client.Update(ctx, controlplane)
 		if err != nil {
 			if k8serrors.IsConflict(err) {

--- a/controllers/controlplane_controller.go
+++ b/controllers/controlplane_controller.go
@@ -72,9 +72,9 @@ func (r *ControlPlaneReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	debug(log, "validating ControlPlane configuration", controlplane)
-	// TODO: add validating here
+	// TODO: add validating here: https://github.com/Kong/gateway-operator/issues/109
 
-	debug(log, "setting defaults for ControlPlane resource", controlplane)
+	debug(log, "configuring ControlPlane resource", controlplane)
 	changed := setControlPlaneDefaults(&controlplane.Spec.ControlPlaneDeploymentOptions, controlplane.Namespace, dataplaneServiceName, nil)
 	if changed {
 		debug(log, "updating ControlPlane resource after defaults are set since resource has changed", controlplane)

--- a/controllers/controlplane_controller_utils.go
+++ b/controllers/controlplane_controller_utils.go
@@ -20,35 +20,62 @@ import (
 // ControlPlane - Private Functions
 // -----------------------------------------------------------------------------
 
-func setControlPlaneDefaults(spec *operatorv1alpha1.ControlPlaneDeploymentOptions, namespace string, dataplaneServiceName string, dontOverride map[string]struct{}) {
-	spec.Env = append(spec.Env, corev1.EnvVar{Name: "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY", Value: "true"}) // TODO: for poc only, don't release with this https://github.com/Kong/gateway-operator/issues/7
-	spec.Env = append(spec.Env, corev1.EnvVar{
-		Name: "POD_NAMESPACE",
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				APIVersion: "v1",
-				FieldPath:  "metadata.namespace",
-			},
+// setControlPlaneDefaults update the environment variables of control plane
+// and returns true if env field is changed.
+func setControlPlaneDefaults(
+	spec *operatorv1alpha1.ControlPlaneDeploymentOptions,
+	namespace string, dataplaneServiceName string,
+	dontOverride map[string]struct{},
+) bool {
+	changed := false
+
+	if envValueByName(spec.Env, "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY") != "true" {
+		// TODO: for poc only, don't release with this https://github.com/Kong/gateway-operator/issues/7
+		spec.Env = append(spec.Env, corev1.EnvVar{Name: "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY", Value: "true"})
+		changed = true
+	}
+
+	// set env POD_NAMESPACE. should be always from `metadata.namespace` of pod.
+	envSourceMetadataNamespace := &corev1.EnvVarSource{
+		FieldRef: &corev1.ObjectFieldSelector{
+			APIVersion: "v1",
+			FieldPath:  "metadata.namespace",
 		},
-	})
-	spec.Env = append(spec.Env, corev1.EnvVar{
-		Name: "POD_NAME",
-		ValueFrom: &corev1.EnvVarSource{
-			FieldRef: &corev1.ObjectFieldSelector{
-				APIVersion: "v1",
-				FieldPath:  "metadata.name",
-			},
+	}
+	if !reflect.DeepEqual(envSourceMetadataNamespace, envVarSourceByName(spec.Env, "POD_NAMESPACE")) {
+		spec.Env = updateEnvSource(spec.Env, "POD_NAMESPACE", envSourceMetadataNamespace)
+		changed = true
+	}
+
+	// set env POD_NAME. should be always from `metadata.name` of pod.
+	envSourceMetadataName := &corev1.EnvVarSource{
+		FieldRef: &corev1.ObjectFieldSelector{
+			APIVersion: "v1",
+			FieldPath:  "metadata.name",
 		},
-	})
+	}
+	if !reflect.DeepEqual(envSourceMetadataName, envVarSourceByName(spec.Env, "POD_NAME")) {
+		spec.Env = updateEnvSource(spec.Env, "POD_NAME", envSourceMetadataName)
+		changed = true
+	}
 
 	if namespace != "" && dataplaneServiceName != "" {
 		if _, isOverrideDisabled := dontOverride["CONTROLLER_PUBLISH_SERVICE"]; !isOverrideDisabled {
-			spec.Env = updateEnv(spec.Env, "CONTROLLER_PUBLISH_SERVICE", controllerPublishService(dataplaneServiceName, namespace))
+			publishService := controllerPublishService(dataplaneServiceName, namespace)
+			if envValueByName(spec.Env, "CONTROLLER_PUBLISH_SERVICE") != publishService {
+				spec.Env = updateEnv(spec.Env, "CONTROLLER_PUBLISH_SERVICE", controllerPublishService(dataplaneServiceName, namespace))
+				changed = true
+			}
 		}
 		if _, isOverrideDisabled := dontOverride["CONTROLLER_KONG_ADMIN_URL"]; !isOverrideDisabled {
-			spec.Env = updateEnv(spec.Env, "CONTROLLER_KONG_ADMIN_URL", controllerKongAdminURL(dataplaneServiceName, namespace))
+			kongAdminURL := controllerKongAdminURL(dataplaneServiceName, namespace)
+			if envValueByName(spec.Env, "CONTROLLER_KONG_ADMIN_URL") != kongAdminURL {
+				spec.Env = updateEnv(spec.Env, "CONTROLLER_KONG_ADMIN_URL", kongAdminURL)
+				changed = true
+			}
 		}
 	}
+	return changed
 }
 
 func setControlPlaneEnvOnDataPlaneChange(
@@ -104,6 +131,17 @@ func envValueByName(env []corev1.EnvVar, name string) string {
 	return ""
 }
 
+// envVarSourceByName returns the VarSource of the first env var with the given name.
+// returns nil if env var is not found, or does not have a ValueFrom field.
+func envVarSourceByName(env []corev1.EnvVar, name string) *corev1.EnvVarSource {
+	for _, envVar := range env {
+		if envVar.Name == name {
+			return envVar.ValueFrom
+		}
+	}
+	return nil
+}
+
 func updateEnv(envVars []corev1.EnvVar, name, val string) []corev1.EnvVar {
 	newEnvVars := make([]corev1.EnvVar, 0, len(envVars))
 	for _, envVar := range envVars {
@@ -115,6 +153,23 @@ func updateEnv(envVars []corev1.EnvVar, name, val string) []corev1.EnvVar {
 	newEnvVars = append(newEnvVars, corev1.EnvVar{
 		Name:  name,
 		Value: val,
+	})
+
+	return newEnvVars
+}
+
+// updateEnvSource updates env var with `name` to come from `envSource`.
+func updateEnvSource(envVars []corev1.EnvVar, name string, envSource *corev1.EnvVarSource) []corev1.EnvVar {
+	newEnvVars := make([]corev1.EnvVar, 0, len(envVars))
+	for _, envVar := range envVars {
+		if envVar.Name != name {
+			newEnvVars = append(newEnvVars, envVar)
+		}
+	}
+
+	newEnvVars = append(newEnvVars, corev1.EnvVar{
+		Name:      name,
+		ValueFrom: envSource,
 	})
 
 	return newEnvVars

--- a/controllers/controlplane_controller_utils_test.go
+++ b/controllers/controlplane_controller_utils_test.go
@@ -1,0 +1,181 @@
+package controllers
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	operatorv1alpha1 "github.com/kong/gateway-operator/apis/v1alpha1"
+)
+
+func TestSetControlPlaneDefaults(t *testing.T) {
+	testCases := []struct {
+		name                 string
+		spec                 *operatorv1alpha1.ControlPlaneDeploymentOptions
+		namespace            string
+		dataplaceServiceName string
+		changed              bool
+		newSpec              *operatorv1alpha1.ControlPlaneDeploymentOptions
+	}{
+		{
+			name:    "no_envs_no_dataplane",
+			spec:    &operatorv1alpha1.ControlPlaneDeploymentOptions{},
+			changed: true,
+			newSpec: &operatorv1alpha1.ControlPlaneDeploymentOptions{
+				DeploymentOptions: operatorv1alpha1.DeploymentOptions{
+					Env: []corev1.EnvVar{
+						{Name: "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY", Value: "true"},
+						{
+							Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1", FieldPath: "metadata.namespace",
+								},
+							},
+						},
+						{
+							Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1", FieldPath: "metadata.name",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:                 "no_envs_has_dataplane",
+			spec:                 &operatorv1alpha1.ControlPlaneDeploymentOptions{},
+			changed:              true,
+			namespace:            "test-ns",
+			dataplaceServiceName: "kong-proxy",
+			newSpec: &operatorv1alpha1.ControlPlaneDeploymentOptions{
+				DeploymentOptions: operatorv1alpha1.DeploymentOptions{
+					Env: []corev1.EnvVar{
+						{Name: "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY", Value: "true"},
+						{
+							Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1", FieldPath: "metadata.namespace",
+								},
+							},
+						},
+						{
+							Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1", FieldPath: "metadata.name",
+								},
+							},
+						},
+						{Name: "CONTROLLER_PUBLISH_SERVICE", Value: "test-ns/kong-proxy"},
+						{Name: "CONTROLLER_KONG_ADMIN_URL", Value: "https://kong-proxy.test-ns.svc:8444"},
+					},
+				},
+			},
+		},
+		{
+			name: "has_envs_and_dataplane",
+			spec: &operatorv1alpha1.ControlPlaneDeploymentOptions{
+				DeploymentOptions: operatorv1alpha1.DeploymentOptions{
+					Env: []corev1.EnvVar{
+						{Name: "TEST_ENV", Value: "test"},
+					},
+				},
+			},
+			changed:              true,
+			namespace:            "test-ns",
+			dataplaceServiceName: "kong-proxy",
+			newSpec: &operatorv1alpha1.ControlPlaneDeploymentOptions{
+				DeploymentOptions: operatorv1alpha1.DeploymentOptions{
+					Env: []corev1.EnvVar{
+						{Name: "TEST_ENV", Value: "test"},
+						{Name: "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY", Value: "true"},
+						{
+							Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1", FieldPath: "metadata.namespace",
+								},
+							},
+						},
+						{
+							Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1", FieldPath: "metadata.name",
+								},
+							},
+						},
+						{Name: "CONTROLLER_PUBLISH_SERVICE", Value: "test-ns/kong-proxy"},
+						{Name: "CONTROLLER_KONG_ADMIN_URL", Value: "https://kong-proxy.test-ns.svc:8444"},
+					},
+				},
+			},
+		},
+		{
+			name: "has_dataplane_env_unchanged",
+			spec: &operatorv1alpha1.ControlPlaneDeploymentOptions{
+				DeploymentOptions: operatorv1alpha1.DeploymentOptions{
+					Env: []corev1.EnvVar{
+						{Name: "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY", Value: "true"},
+						{
+							Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1", FieldPath: "metadata.namespace",
+								},
+							},
+						},
+						{
+							Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1", FieldPath: "metadata.name",
+								},
+							},
+						},
+						{Name: "CONTROLLER_PUBLISH_SERVICE", Value: "test-ns/kong-proxy"},
+						{Name: "CONTROLLER_KONG_ADMIN_URL", Value: "https://kong-proxy.test-ns.svc:8444"},
+					},
+				},
+			},
+			namespace:            "test-ns",
+			dataplaceServiceName: "kong-proxy",
+			changed:              false,
+			newSpec: &operatorv1alpha1.ControlPlaneDeploymentOptions{
+				DeploymentOptions: operatorv1alpha1.DeploymentOptions{
+					Env: []corev1.EnvVar{
+						{Name: "CONTROLLER_KONG_ADMIN_TLS_SKIP_VERIFY", Value: "true"},
+						{
+							Name: "POD_NAMESPACE", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1", FieldPath: "metadata.namespace",
+								},
+							},
+						},
+						{
+							Name: "POD_NAME", ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{
+									APIVersion: "v1", FieldPath: "metadata.name",
+								},
+							},
+						},
+						{Name: "CONTROLLER_PUBLISH_SERVICE", Value: "test-ns/kong-proxy"},
+						{Name: "CONTROLLER_KONG_ADMIN_URL", Value: "https://kong-proxy.test-ns.svc:8444"},
+					},
+				},
+			},
+		},
+	}
+
+	for i, tc := range testCases {
+		index := i
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			changed := setControlPlaneDefaults(tc.spec, tc.namespace, tc.dataplaceServiceName, map[string]struct{}{})
+			require.Equalf(t, tc.changed, changed,
+				"should return the same value for test case %d:%s", index, tc.name)
+			require.Truef(t, reflect.DeepEqual(tc.spec, tc.newSpec),
+				"the updated spec should be equal to expected for test case %d:%s\nexpected: %+v\nactual: %+v",
+				index, tc.name, tc.newSpec, tc.spec)
+		})
+	}
+}

--- a/test/integration/controlplane_test.go
+++ b/test/integration/controlplane_test.go
@@ -4,12 +4,15 @@
 package integration
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -75,7 +78,15 @@ func TestControlPlaneWhenNoDataPlane(t *testing.T) {
 	require.Eventually(t, dataPlaneHasActiveDeployment(t, dataplaneName), controlPlanetCondDeadline, controlPlanetCondTick)
 
 	t.Log("verifying services managed by the dataplane")
-	require.Eventually(t, dataPlaneHasService(t, dataplaneName), controlPlanetCondDeadline, controlPlanetCondTick)
+	require.Eventually(t, dataPlaneHasService(t, dataplaneName), controlPlanetCondDeadline, controlPlanetCondTick,
+		func() string {
+			controlplane, err := controlplaneClient.Get(ctx, controlplaneName.Name, metav1.GetOptions{})
+			if err != nil {
+				return err.Error()
+			}
+			return fmt.Sprintf("current status of control plane: %#v", controlplane)
+		}(),
+	)
 
 	t.Log("attaching dataplane to controlplane")
 	controlplane, err = controlplaneClient.Get(ctx, controlplane.Name, metav1.GetOptions{})
@@ -131,6 +142,11 @@ func TestControlPlaneEssentials(t *testing.T) {
 		},
 		Spec: operatorv1alpha1.ControlPlaneSpec{
 			ControlPlaneDeploymentOptions: operatorv1alpha1.ControlPlaneDeploymentOptions{
+				DeploymentOptions: operatorv1alpha1.DeploymentOptions{
+					Env: []corev1.EnvVar{
+						{Name: "TEST_ENV", Value: "test"},
+					},
+				},
 				DataPlane: &dataplane.Name,
 			},
 		},
@@ -156,8 +172,36 @@ func TestControlPlaneEssentials(t *testing.T) {
 	require.Eventually(t, controlPlaneIsScheduled(t, controlplaneName), controlPlanetCondDeadline, controlPlanetCondTick)
 
 	t.Log("verifying that the controlplane gets marked as provisioned")
-	require.Eventually(t, controlPlaneIsProvisioned(t, controlplaneName), controlPlanetCondDeadline, controlPlanetCondTick)
+	require.Eventually(t, controlPlaneIsProvisioned(t, controlplaneName), controlPlanetCondDeadline, controlPlanetCondTick,
+		func() string {
+			controlplane, err := controlplaneClient.Get(ctx, controlplaneName.Name, metav1.GetOptions{})
+			if err != nil {
+				return err.Error()
+			}
+			return fmt.Sprintf("current status of control plane: %#v", controlplane)
+		}(),
+	)
 
 	t.Log("verifying controlplane deployment has active replicas")
 	require.Eventually(t, controlPlaneHasActiveDeployment(t, controlplaneName), controlPlanetCondDeadline, controlPlanetCondTick)
+
+	// check environment variables of deployments and pods.
+	deployments := mustListControlPlaneDeployments(t, controlplane)
+	require.Len(t, deployments, 1, "must have exactly 1 deployment")
+	deployment := deployments[0]
+	controllerContainer := getContainerWithNameInPod(&deployment.Spec.Template.Spec, "controller")
+	require.NotNil(t, controllerContainer)
+
+	envs := controllerContainer.Env
+	t.Log("verifying env POD_NAME comes from metadata.name")
+	podNameValueFrom := getEnvValueFromByName(envs, "POD_NAME")
+	require.True(t, reflect.DeepEqual(&corev1.EnvVarSource{
+		FieldRef: &corev1.ObjectFieldSelector{
+			APIVersion: "v1",
+			FieldPath:  "metadata.name",
+		},
+	}, podNameValueFrom))
+	t.Log("verifying custom env TEST_ENV has value configured in controlplane")
+	testEnvValue := getEnvValueByName(envs, "TEST_ENV")
+	require.Equal(t, "test", testEnvValue)
 }

--- a/test/integration/util_test.go
+++ b/test/integration/util_test.go
@@ -164,3 +164,37 @@ func getFirstNonLoopbackIP() (string, error) {
 
 	return "", fmt.Errorf("no available IPs")
 }
+
+func getContainerWithNameInPod(podSpec *corev1.PodSpec, name string) *corev1.Container {
+	for i, container := range podSpec.Containers {
+		if container.Name == name {
+			return &podSpec.Containers[i]
+		}
+	}
+	return nil
+}
+
+// getEnvValueByName returns the corresponding value of LAST item with given name.
+// returns empty string if the name not appeared.
+func getEnvValueByName(envs []corev1.EnvVar, name string) string {
+	value := ""
+	for _, env := range envs {
+		if env.Name == name {
+			value = env.Value
+		}
+	}
+	return value
+}
+
+// getEnvValueFromByName returns the corresponding ValueFrom pointer of LAST item with given name.
+// returns nil if the name not appeared.
+func getEnvValueFromByName(envs []corev1.EnvVar, name string) *corev1.EnvVarSource {
+	var valueFrom *corev1.EnvVarSource
+	for _, env := range envs {
+		if env.Name == name {
+			valueFrom = env.ValueFrom
+		}
+	}
+
+	return valueFrom
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://github.com/kubernetes/community/blob/master/contributors/devel/development.md
2. If you want *faster* PR reviews, read how: https://github.com/kubernetes/community/blob/master/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md and ensure your changes are being reflected in CHANGELOG.md for the next upcoming release
-->

**What this PR does / why we need it**:

always set default environment variables for `controlplane` resource, fix the bug that `POD_NAME` and `POD_NAMESPACE` is not set when any `env` specified in `ControlPlane`

**Which issue this PR fixes**

fixes #63

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
