### PR TITLE
fix: gatway watches network policies

### DIFF
--- a/controllers/gateway_controller.go
+++ b/controllers/gateway_controller.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -40,6 +41,14 @@ type GatewayReconciler struct {
 func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	c, err := controller.New("gateway", mgr, controller.Options{Reconciler: r})
 	if err != nil {
+		return err
+	}
+
+	// watch for changes in the networkpolicies created by the gateway operator
+	if err := c.Watch(
+		&source.Kind{Type: &networkingv1.NetworkPolicy{}},
+		&handler.EnqueueRequestForOwner{OwnerType: &gatewayv1alpha2.Gateway{}},
+	); err != nil {
 		return err
 	}
 
@@ -152,8 +161,8 @@ func (r *GatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 
 	// DataPlane NetworkPolicies
-	debug(log, "ensuring DataPlane's NetworkPolicy are is created", gateway)
-	if err := r.ensureDataPlaneNetworkPolicy(ctx, gateway, dataplane, controlplane); err != nil {
+	debug(log, "ensuring DataPlane's NetworkPolicy is created", gateway)
+	if err := r.ensureDataPlaneHasNetworkPolicy(ctx, gateway, dataplane, controlplane); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/gateway_controller_reconciler_utils.go
+++ b/controllers/gateway_controller_reconciler_utils.go
@@ -190,7 +190,7 @@ func (r *GatewayReconciler) getGatewayConfigForGatewayClass(ctx context.Context,
 	}, gatewayConfig)
 }
 
-func (r *GatewayReconciler) ensureDataPlaneNetworkPolicy(
+func (r *GatewayReconciler) ensureDataPlaneHasNetworkPolicy(
 	ctx context.Context,
 	gateway *gatewayDecorator,
 	dataplane *operatorv1alpha1.DataPlane,
@@ -205,7 +205,7 @@ func (r *GatewayReconciler) ensureDataPlaneNetworkPolicy(
 
 	numNetworkPolicies := len(networkPolicies)
 	if len(networkPolicies) > 1 {
-		return fmt.Errorf("%w, got %d, expected 1", operatorerrors.ErrTooManyDataPlaneNetworkPolicies, numNetworkPolicies)
+		return fmt.Errorf("%w, got: %d, expected 1", operatorerrors.ErrTooManyDataPlaneNetworkPolicies, numNetworkPolicies)
 	}
 
 	if len(networkPolicies) == 0 {
@@ -215,6 +215,8 @@ func (r *GatewayReconciler) ensureDataPlaneNetworkPolicy(
 
 		return r.Client.Create(ctx, policy)
 	}
+
+	
 
 	return nil
 }

--- a/controllers/gateway_controller_reconciler_utils.go
+++ b/controllers/gateway_controller_reconciler_utils.go
@@ -216,8 +216,6 @@ func (r *GatewayReconciler) ensureDataPlaneHasNetworkPolicy(
 		return r.Client.Create(ctx, policy)
 	}
 
-	
-
 	return nil
 }
 

--- a/test/integration/asserts_test.go
+++ b/test/integration/asserts_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -91,4 +92,10 @@ func mustGetGateway(t *testing.T, gatewayNSN types.NamespacedName) *v1alpha2.Gat
 	gateway, err := gateways.Get(ctx, gatewayNSN.Name, metav1.GetOptions{})
 	require.NoError(t, err)
 	return gateway
+}
+
+func mustListGatewayNetworkPolicies(t *testing.T, ctx context.Context, gateway *gatewayv1alpha2.Gateway) []networkingv1.NetworkPolicy {
+	networkpolicies, err := gatewayutils.ListNetworkPoliciesForGateway(ctx, mgrClient, gateway)
+	require.NoError(t, err)
+	return networkpolicies
 }

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -152,7 +152,7 @@ func TestGatewayDataPlaneNetworkPolicy(t *testing.T) {
 	expectAllowProxyIngress.withProtocolPort(corev1.ProtocolTCP, consts.DataPlaneProxyPort)
 	expectAllowProxyIngress.withProtocolPort(corev1.ProtocolTCP, consts.DataPlaneProxySSLPort)
 
-	// DataPlane's metrics ingress traffic should be allowed
+	t.Log("verifying that the DataPlane's metrics ingress traffic is allowed")
 	var expectAllowMetricsIngress networkPolicyIngressRuleDecorator
 	expectAllowMetricsIngress.withProtocolPort(corev1.ProtocolTCP, consts.DataPlaneMetricsPort)
 

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -147,7 +147,7 @@ func TestGatewayDataPlaneNetworkPolicy(t *testing.T) {
 		map[string]string{"kubernetes.io/metadata.name": dataplane.Namespace},
 	)
 
-	// DataPlane's proxy ingress traffic should be allowed
+	t.Log("verifying that the DataPlane's proxy ingress traffic is allowed")
 	var expectAllowProxyIngress networkPolicyIngressRuleDecorator
 	expectAllowProxyIngress.withProtocolPort(corev1.ProtocolTCP, consts.DataPlaneProxyPort)
 	expectAllowProxyIngress.withProtocolPort(corev1.ProtocolTCP, consts.DataPlaneProxySSLPort)

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -139,7 +139,7 @@ func TestGatewayDataPlaneNetworkPolicy(t *testing.T) {
 	networkPolicy := networkpolicies[0]
 	require.Equal(t, map[string]string{"app": dataplane.Name}, networkPolicy.Spec.PodSelector.MatchLabels)
 
-	// DataPlane's pod Admin API should be limited to controlplane pods
+	t.Log("verifying that the DataPlane's Pod Admin API is network restricted to ControlPlane Pods")
 	var expectLimitedAdminAPI networkPolicyIngressRuleDecorator
 	expectLimitedAdminAPI.withProtocolPort(corev1.ProtocolTCP, consts.DataPlaneAdminAPIPort)
 	expectLimitedAdminAPI.withPeerMatchLabels(

--- a/test/integration/gateway_test.go
+++ b/test/integration/gateway_test.go
@@ -10,11 +10,15 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	gatewayv1alpha2 "sigs.k8s.io/gateway-api/apis/v1alpha2"
 
+	"github.com/kong/gateway-operator/internal/consts"
 	"github.com/kong/gateway-operator/pkg/vars"
 )
 
@@ -34,14 +38,7 @@ func TestGatewayEssentials(t *testing.T) {
 	defer func() { assert.NoError(t, cleaner.Cleanup(ctx)) }()
 
 	t.Log("deploying a GatewayClass resource")
-	gatewayClass := &gatewayv1alpha2.GatewayClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: uuid.NewString(),
-		},
-		Spec: gatewayv1alpha2.GatewayClassSpec{
-			ControllerName: gatewayv1alpha2.GatewayController(vars.ControllerName),
-		},
-	}
+	gatewayClass := generateGatewayClass()
 	gatewayClass, err := gatewayClient.GatewayV1alpha2().GatewayClasses().Create(ctx, gatewayClass, metav1.CreateOptions{})
 	require.NoError(t, err)
 	cleaner.Add(gatewayClass)
@@ -51,20 +48,7 @@ func TestGatewayEssentials(t *testing.T) {
 		Name:      uuid.NewString(),
 		Namespace: namespace.Name,
 	}
-	gateway := &gatewayv1alpha2.Gateway{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: gatewayNSN.Namespace,
-			Name:      gatewayNSN.Name,
-		},
-		Spec: gatewayv1alpha2.GatewaySpec{
-			GatewayClassName: gatewayv1alpha2.ObjectName(gatewayClass.Name),
-			Listeners: []gatewayv1alpha2.Listener{{
-				Name:     "http",
-				Protocol: gatewayv1alpha2.HTTPProtocolType,
-				Port:     gatewayv1alpha2.PortNumber(80),
-			}},
-		},
-	}
+	gateway := generateGateway(gatewayNSN, gatewayClass)
 	gateway, err = gatewayClient.GatewayV1alpha2().Gateways(namespace.Name).Create(ctx, gateway, metav1.CreateOptions{})
 	require.NoError(t, err)
 	cleaner.Add(gateway)
@@ -112,4 +96,148 @@ func TestGatewayEssentials(t *testing.T) {
 
 	t.Log("verifying networkpolicies are deleted")
 	require.Eventually(t, Not(gatewayNetworkPoliciesExist(t, ctx, gateway)), time.Minute, time.Second)
+}
+
+func TestGatewayDataPlaneNetworkPolicy(t *testing.T) {
+	namespace, cleaner := setup(t)
+	defer func() { assert.NoError(t, cleaner.Cleanup(ctx)) }()
+
+	t.Log("deploying a GatewayClass resource")
+	gatewayClass := generateGatewayClass()
+	gatewayClass, err := gatewayClient.GatewayV1alpha2().GatewayClasses().Create(ctx, gatewayClass, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gatewayClass)
+
+	t.Log("deploying Gateway resource")
+	gatewayNSN := types.NamespacedName{
+		Name:      uuid.NewString(),
+		Namespace: namespace.Name,
+	}
+	gateway := generateGateway(gatewayNSN, gatewayClass)
+	gateway, err = gatewayClient.GatewayV1alpha2().Gateways(namespace.Name).Create(ctx, gateway, metav1.CreateOptions{})
+	require.NoError(t, err)
+	cleaner.Add(gateway)
+
+	t.Log("verifying Gateway gets marked as Scheduled")
+	require.Eventually(t, gatewayIsScheduled(t, ctx, gatewayNSN), gatewaySchedulingTimeLimit, time.Second)
+
+	t.Log("verifying Gateway gets marked as Ready")
+	require.Eventually(t, gatewayIsReady(t, ctx, gatewayNSN), gatewayReadyTimeLimit, time.Second)
+
+	t.Log("verifying that the DataPlane becomes provisioned")
+	require.Eventually(t, gatewayDataPlaneIsProvisioned(t, gateway), subresourceReadinessWait, time.Second)
+	dataplane := mustListDataPlanesForGateway(t, gateway)[0]
+
+	t.Log("verifying that the ControlPlane becomes provisioned")
+	require.Eventually(t, gatewayControlPlaneIsProvisioned(t, gateway), subresourceReadinessWait, time.Second)
+	controlplane := mustListControlPlanesForGateway(t, gateway)[0]
+
+	t.Log("verifying DataPlane's NetworkPolicies is created")
+	require.Eventually(t, gatewayNetworkPoliciesExist(t, ctx, gateway), subresourceReadinessWait, time.Second)
+	networkpolicies := mustListGatewayNetworkPolicies(t, ctx, gateway)
+	require.Len(t, networkpolicies, 1)
+	networkPolicy := networkpolicies[0]
+	require.Equal(t, map[string]string{"app": dataplane.Name}, networkPolicy.Spec.PodSelector.MatchLabels)
+
+	// DataPlane's pod Admin API should be limited to controlplane pods
+	var expectLimitedAdminAPI networkPolicyIngressRuleDecorator
+	expectLimitedAdminAPI.withProtocolPort(corev1.ProtocolTCP, consts.DataPlaneAdminAPIPort)
+	expectLimitedAdminAPI.withPeerMatchLabels(
+		map[string]string{"app": controlplane.Name},
+		map[string]string{"kubernetes.io/metadata.name": dataplane.Namespace},
+	)
+
+	// DataPlane's proxy ingress traffic should be allowed
+	var expectAllowProxyIngress networkPolicyIngressRuleDecorator
+	expectAllowProxyIngress.withProtocolPort(corev1.ProtocolTCP, consts.DataPlaneProxyPort)
+	expectAllowProxyIngress.withProtocolPort(corev1.ProtocolTCP, consts.DataPlaneProxySSLPort)
+
+	// DataPlane's metrics ingress traffic should be allowed
+	var expectAllowMetricsIngress networkPolicyIngressRuleDecorator
+	expectAllowMetricsIngress.withProtocolPort(corev1.ProtocolTCP, consts.DataPlaneMetricsPort)
+
+	t.Log("verifying DataPlane's NetworkPolicies ingress rules correctness")
+	require.Contains(t, networkPolicy.Spec.Ingress, expectLimitedAdminAPI.Rule)
+	require.Contains(t, networkPolicy.Spec.Ingress, expectAllowProxyIngress.Rule)
+	require.Contains(t, networkPolicy.Spec.Ingress, expectAllowMetricsIngress.Rule)
+
+	t.Log("deleting DataPlane's NetworkPolicies")
+	require.NoError(t,
+		k8sClient.NetworkingV1().
+			NetworkPolicies(networkPolicy.Namespace).
+			Delete(ctx, networkPolicy.Name, metav1.DeleteOptions{}),
+	)
+
+	t.Log("verifying NetworkPolicies are recreated")
+	require.Eventually(t, gatewayNetworkPoliciesExist(t, ctx, gateway), subresourceReadinessWait, time.Second)
+	networkpolicies = mustListGatewayNetworkPolicies(t, ctx, gateway)
+	require.Len(t, networkpolicies, 1)
+	networkPolicy = networkpolicies[0]
+
+	t.Log("verifying DataPlane's NetworkPolicies ingress rules correctness")
+	require.Contains(t, networkPolicy.Spec.Ingress, expectLimitedAdminAPI.Rule)
+	require.Contains(t, networkPolicy.Spec.Ingress, expectAllowProxyIngress.Rule)
+	require.Contains(t, networkPolicy.Spec.Ingress, expectAllowMetricsIngress.Rule)
+
+	t.Log("deleting Gateway resource")
+	require.NoError(t, gatewayClient.GatewayV1alpha2().Gateways(namespace.Name).Delete(ctx, gateway.Name, metav1.DeleteOptions{}))
+
+	t.Log("verifying networkpolicies are deleted")
+	require.Eventually(t, Not(gatewayNetworkPoliciesExist(t, ctx, gateway)), time.Minute, time.Second)
+}
+
+type networkPolicyIngressRuleDecorator struct {
+	Rule networkingv1.NetworkPolicyIngressRule
+}
+
+func (d *networkPolicyIngressRuleDecorator) withProtocolPort(protocol corev1.Protocol, port int) {
+	portIntStr := intstr.FromInt(port)
+	d.Rule.Ports = append(d.Rule.Ports, networkingv1.NetworkPolicyPort{
+		Protocol: &protocol,
+		Port:     &portIntStr,
+	})
+}
+
+func (d *networkPolicyIngressRuleDecorator) withPeerMatchLabels(
+	podSelector map[string]string,
+	namespaceSelector map[string]string,
+) {
+	d.Rule.From = append(d.Rule.From, networkingv1.NetworkPolicyPeer{
+		PodSelector: &metav1.LabelSelector{
+			MatchLabels: podSelector,
+		},
+		NamespaceSelector: &metav1.LabelSelector{
+			MatchLabels: namespaceSelector,
+		},
+	})
+}
+
+func generateGatewayClass() *gatewayv1alpha2.GatewayClass {
+	gatewayClass := &gatewayv1alpha2.GatewayClass{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: uuid.NewString(),
+		},
+		Spec: gatewayv1alpha2.GatewayClassSpec{
+			ControllerName: gatewayv1alpha2.GatewayController(vars.ControllerName),
+		},
+	}
+	return gatewayClass
+}
+
+func generateGateway(gatewayNSN types.NamespacedName, gatewayClass *gatewayv1alpha2.GatewayClass) *gatewayv1alpha2.Gateway {
+	gateway := &gatewayv1alpha2.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: gatewayNSN.Namespace,
+			Name:      gatewayNSN.Name,
+		},
+		Spec: gatewayv1alpha2.GatewaySpec{
+			GatewayClassName: gatewayv1alpha2.ObjectName(gatewayClass.Name),
+			Listeners: []gatewayv1alpha2.Listener{{
+				Name:     "http",
+				Protocol: gatewayv1alpha2.HTTPProtocolType,
+				Port:     gatewayv1alpha2.PortNumber(80),
+			}},
+		},
+	}
+	return gateway
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is internal PR, between branches. Gateway controller watches network policies that is created, so it can recreate it when deleted.

**Which issue this PR fixes**

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
