### PR TITLE
fix: handle webhook availability in test

### DIFF
--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -4,8 +4,6 @@
 package e2e
 
 import (
-	"errors"
-	"syscall"
 	"testing"
 	"time"
 
@@ -13,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	netutil "k8s.io/apimachinery/pkg/util/net"
 
 	operatorv1alpha1 "github.com/kong/gateway-operator/apis/v1alpha1"
 )
@@ -69,7 +68,7 @@ func TestDataplaneValidatingWebhook(t *testing.T) {
 				if tc.errMsg == "" {
 					return err == nil
 				}
-				return !errors.Is(err, syscall.ECONNREFUSED)
+				return !netutil.IsConnectionRefused(err)
 			}, time.Minute*3, time.Second)
 			if tc.errMsg == "" {
 				require.NoErrorf(t, err, "test case %s: should not return error when creating dataplane", tc.name)

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -4,7 +4,10 @@
 package e2e
 
 import (
+	"errors"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
@@ -60,7 +63,14 @@ func TestDataplaneValidatingWebhook(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			dataplaneClient := operatorClient.ApisV1alpha1().DataPlanes(testNamespace.Name)
-			_, err := dataplaneClient.Create(ctx, tc.dataplane, metav1.CreateOptions{})
+			var err error
+			require.Eventually(t, func() bool {
+				_, err = dataplaneClient.Create(ctx, tc.dataplane, metav1.CreateOptions{})
+				if tc.errMsg == "" {
+					return err == nil
+				}
+				return !errors.Is(err, syscall.ECONNREFUSED)
+			}, time.Minute*3, time.Second)
 			if tc.errMsg == "" {
 				require.NoErrorf(t, err, "test case %s: should not return error when creating dataplane", tc.name)
 			} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Retries webhook test stuff if the webhook isn't up yet.

**Which issue this PR fixes**
fix #100 