### PR TITLE
chore: add diagnostics for webhook test

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -93,6 +93,14 @@ jobs:
       env:
         KONG_CONTROLLER_OUT: stdout
 
+    - name: upload diagnostics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagnostics-integration-tests-enterprise-postgres
+        path: /tmp/ktf-diag*
+        if-no-files-found: ignore
+
   e2e-tests:
     runs-on: ubuntu-latest
     steps:
@@ -125,3 +133,11 @@ jobs:
       run: make test.e2e
       env:
         KONG_TEST_GATEWAY_OPERATOR_IMAGE_LOAD: gateway-operator:e2e-${{ github.sha }}
+
+    - name: upload diagnostics
+      if: ${{ always() }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: diagnostics-integration-tests-enterprise-postgres
+        path: /tmp/ktf-diag*
+        if-no-files-found: ignore

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/go-logr/logr v1.2.3
 	github.com/google/uuid v1.3.0
-	github.com/kong/kubernetes-testing-framework v0.17.0
+	github.com/kong/kubernetes-testing-framework v0.18.0
 	github.com/stretchr/testify v1.8.0
 	k8s.io/api v0.24.3
 	k8s.io/apimachinery v0.24.3

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,8 @@ github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kong/kubernetes-testing-framework v0.17.0 h1:aIUbv4ZHBIOkxm32nwdWprSR8ZoxVtt7KajrbMVRokE=
 github.com/kong/kubernetes-testing-framework v0.17.0/go.mod h1:PINr9exqi9BDxsCpGgRHGZhnwbu2MdFl1YQzRI3Azxg=
+github.com/kong/kubernetes-testing-framework v0.18.0 h1:fWevY5sG1x4nfdf5kjfmpeJGcn1PG7qnqo1TOZEiOiE=
+github.com/kong/kubernetes-testing-framework v0.18.0/go.mod h1:ZVzmZsd8Nc5hxkwrgnzvW7vKzSxUh19lZsKm8rnEMI8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,8 +17,15 @@ import (
 
 func TestDataplaneValidatingWebhook(t *testing.T) {
 	t.Log("start tests")
-	testNamespace, cleanup := createNamespaceForTest(t)
-	defer cleanup()
+	testNamespace, cleaner := setup(t)
+	defer func() {
+		if t.Failed() {
+			output, err := cleaner.DumpDiagnostics(ctx, t.Name())
+			t.Logf("%s failed, dumped diagnostics to %s", t.Name(), output)
+			assert.NoError(t, err)
+		}
+		assert.NoError(t, cleaner.Cleanup(ctx))
+	}()
 
 	testCases := []struct {
 		name      string

--- a/test/integration/util_test.go
+++ b/test/integration/util_test.go
@@ -29,6 +29,10 @@ const (
 	defaultHTTPPort = 80
 )
 
+// TODO https://github.com/Kong/kubernetes-testing-framework/issues/302
+// we have this in both integration and e2e pkgs, and also in the controller integration pkg
+// they should be standardized
+
 // setup is a helper function for tests which conveniently creates a cluster
 // cleaner (to clean up test resources automatically after the test finishes)
 // and creates a new namespace for the test to use. It also enables parallel


### PR DESCRIPTION
**What this PR does / why we need it**:
#100 [doesn't seem like it should happen](https://github.com/Kong/gateway-operator/issues/100#issuecomment-1203153747). It appears something weird is going on and we shouldn't just expect that sometimes the webhook won't be available when needed and check before individual tests a la #116.

This dumps cluster state to hopefully explain how we're getting these errors after the Deployment becomes ready. Depending on what we learn, we may decided to proceed with #116 or we may find something broken in the tests that we should fix differently.

**Special notes for your reviewer**:
This adds some TODOs where we have duplicate functionality that KTF should handle.