### PR TITLE
fix: checkout repo before running preflight action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -180,6 +180,11 @@ jobs:
             COMMIT=${{ github.sha }}
             REPO_INFO=https://github.com/${{ github.repository }}.git
 
+      - name: checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
       - name: Run Red Hat certification
         uses: ./.github/actions/redhat-certification-action
         with:


### PR DESCRIPTION

**What this PR does / why we need it**:

Local action needs to be checkout out before it can be used. Release pipeline was missing that. 
**Which issue this PR fixes**

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
